### PR TITLE
이미지(생성, 조회, 삭제)

### DIFF
--- a/src/main/java/com/project/BE_banjjokee/model/Image.java
+++ b/src/main/java/com/project/BE_banjjokee/model/Image.java
@@ -2,10 +2,14 @@ package com.project.BE_banjjokee.model;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @Getter
+@NoArgsConstructor
+@ToString(of = {"id", "key", "url"})
 public class Image extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,10 +19,13 @@ public class Image extends BaseEntity {
     @Column(name = "image_key")
     private String key;
 
-    public void setKey(String key) {
+    private String url;
 
+    protected void setKey(String key) {
         this.key = key;
-
     }
 
+    protected void setUrl(String url) {
+        this.url = url;
+    }
 }

--- a/src/main/java/com/project/BE_banjjokee/model/PetImage.java
+++ b/src/main/java/com/project/BE_banjjokee/model/PetImage.java
@@ -1,0 +1,29 @@
+package com.project.BE_banjjokee.model;
+
+import jakarta.persistence.*;
+import lombok.ToString;
+
+@Entity
+@DiscriminatorValue("PET")
+public class PetImage extends Image{
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id")
+    private Pet pet;
+
+    public static PetImage createPetImage(String key, Pet pet) {
+        PetImage image = new PetImage();
+
+        image.setKey(key);
+        image.setUrl(pet.getImgUrl());
+        image.setPet(pet);
+
+        return image;
+    }
+
+    private void setPet(Pet pet) {
+        this.pet = pet;
+    }
+
+
+}

--- a/src/main/java/com/project/BE_banjjokee/model/PostImage.java
+++ b/src/main/java/com/project/BE_banjjokee/model/PostImage.java
@@ -1,6 +1,7 @@
 package com.project.BE_banjjokee.model;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -12,7 +13,8 @@ public class PostImage extends Image{
     @JoinColumn(name = "post_id")
     private Post post;
 
-    public static PostImage createPostImage(String key, Post post) {
+    @Builder
+    public static PostImage createPostImage(String key, String url, Post post) {
 
         PostImage image = new PostImage();
         image.setKey(key);
@@ -22,6 +24,10 @@ public class PostImage extends Image{
     }
 
     private void setPost(Post post) {
+        if (post == null) {
+            this.post = null;
+            return;
+        }
 
         this.post = post;
         post.getImages().add(this);

--- a/src/main/java/com/project/BE_banjjokee/repository/ImageRepository.java
+++ b/src/main/java/com/project/BE_banjjokee/repository/ImageRepository.java
@@ -1,0 +1,46 @@
+package com.project.BE_banjjokee.repository;
+
+import com.project.BE_banjjokee.model.Image;
+import com.project.BE_banjjokee.model.Pet;
+import com.project.BE_banjjokee.model.PetImage;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class ImageRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public void save(Image image) {
+        em.persist(image);
+    }
+
+    public Optional<Image> findById(Long id) {
+        return Optional.ofNullable(em.find(Image.class, id));
+    }
+
+    public List<Image> findAll() {
+        return em.createQuery("select i from Image i", Image.class)
+                .getResultList();
+    }
+
+    public Optional<PetImage> findByPetId(Long petId) {
+        return Optional.ofNullable(
+                em.createQuery(
+                        "select pi from PetImage pi" +
+                                " join pi.pet p" +
+                                " where p.id = :petId", PetImage.class)
+                .setParameter("petId", petId)
+                .getSingleResult());
+    }
+
+    public void deleteImage(Image image) {
+        em.remove(image);
+    }
+
+}

--- a/src/main/java/com/project/BE_banjjokee/service/ImageService.java
+++ b/src/main/java/com/project/BE_banjjokee/service/ImageService.java
@@ -1,0 +1,26 @@
+package com.project.BE_banjjokee.service;
+
+import com.project.BE_banjjokee.model.PostImage;
+import com.project.BE_banjjokee.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+
+    public Long savePostImage(String key, String url) {
+        PostImage image = PostImage.builder()
+                .key(key)
+                .url(url)
+                .build();
+
+        imageRepository.save(image);
+        return image.getId();
+    }
+
+}


### PR DESCRIPTION
이미지 엔티티를 관리하는 레포지토리 생성(생성, 조회, 삭제)

- 동일 트랜잭션 안에서 처리하기 위해 PetService, PostService 에서 Image 엔티티를 저장하는 역할을 하도록 ImageService 클래스를 생성하지 않았습니다. 
- 따라서 PetService 에서 imageRepository 를 이용하여 엔티티 저장, 삭제 과정이 필요합니다.
- PetImage 객체에선 Pet 을 참조하고 있기 때문에 Pet 객체가 저장된 다음 이미지를 저장해야 합니다.
- PetService 에서 이미지 엔티티를 이용할 때 Type 은 PetImage 타입으로 저장, 조회, 수정, 삭제를 해주시면 됩니다.

혹시 PetService 에서 이미지 엔티티를 처리하는 것이 너무 비효율적이라고 생각하시면 말씀해주시면 변경하도록 하겠습니다.