### PR TITLE
feat: 댓글 CRUD 작업 수행시 발생 가능한 예외 처리 추가(dev)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'com.auth0:java-jwt:4.3.0'
 	implementation platform('software.amazon.awssdk:bom:2.20.56')

--- a/src/main/java/com/project/BE_banjjokee/dto/CreateCommentRequest.java
+++ b/src/main/java/com/project/BE_banjjokee/dto/CreateCommentRequest.java
@@ -1,14 +1,17 @@
 package com.project.BE_banjjokee.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 
 @Data
 public class CreateCommentRequest {
 
+    @NotEmpty
     private Long postId;
 
     private Long parentId;
 
+    @NotEmpty
     private String content;
 
 }

--- a/src/main/java/com/project/BE_banjjokee/dto/UpdateCommentRequest.java
+++ b/src/main/java/com/project/BE_banjjokee/dto/UpdateCommentRequest.java
@@ -1,5 +1,6 @@
 package com.project.BE_banjjokee.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,8 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateCommentRequest {
 
+    @NotEmpty
     private Long commentId;
 
+    @NotEmpty
     private String content;
 
 }

--- a/src/main/java/com/project/BE_banjjokee/service/CommentService.java
+++ b/src/main/java/com/project/BE_banjjokee/service/CommentService.java
@@ -35,6 +35,11 @@ public class CommentService {
 
         if (request.getParentId() != null) {
             parentComment = commentRepository.findById(request.getParentId()).orElseThrow(() -> new RuntimeException("잘못된 접근입니다."));
+
+            if (!post.getComments().contains(parentComment)) {
+                throw new RuntimeException("잘못된 접근");
+            }
+
             uuids.add(parentComment.getWriter().getUuid());
         }
 


### PR DESCRIPTION
Create
- 입력받은 게시물과 부모 댓글이 속한 게시물의 불일치 → service 계층에서 부모 댓글이 속한 게시물 확인
- 필수 입력 요소의 미입력(게시물 아이디, 댓글 내용) → @NotEmpty 처리

Update
- 필수 입력 요소의 미입력(댓글 아이디, 댓글 내용) → @NotEmpty 처리(commentId, content)